### PR TITLE
Repo name to dash namespace & typing fixes

### DIFF
--- a/.bumpversion.cfg
+++ b/.bumpversion.cfg
@@ -1,5 +1,5 @@
 [bumpversion]
-current_version = 2.0.3
+current_version = 2.0.4.dev0
 commit = True
 tag = False
 tag_name = v{new_version}

--- a/.bumpversion.cfg
+++ b/.bumpversion.cfg
@@ -27,7 +27,7 @@ replace = version = "{new_version}"
 search = Version: "{current_version}"
 replace = Version: "{new_version}"
 
-[bumpversion:file:serial_weighing_scale/__init__.py]
+[bumpversion:file:serial-weighing-scale/__init__.py]
 search = __version__ = "{current_version}"
 replace = __version__ = "{new_version}"
 

--- a/.bumpversion.cfg
+++ b/.bumpversion.cfg
@@ -27,7 +27,7 @@ replace = version = "{new_version}"
 search = Version: "{current_version}"
 replace = Version: "{new_version}"
 
-[bumpversion:file:serial_weighin_scale/__init__.py]
+[bumpversion:file:serial_weighing_scale/__init__.py]
 search = __version__ = "{current_version}"
 replace = __version__ = "{new_version}"
 

--- a/.bumpversion.cfg
+++ b/.bumpversion.cfg
@@ -27,7 +27,7 @@ replace = version = "{new_version}"
 search = Version: "{current_version}"
 replace = Version: "{new_version}"
 
-[bumpversion:file:serial-weighing-scale/__init__.py]
+[bumpversion:file:serial_weighin_scale/__init__.py]
 search = __version__ = "{current_version}"
 replace = __version__ = "{new_version}"
 

--- a/.bumpversion.cfg
+++ b/.bumpversion.cfg
@@ -1,5 +1,5 @@
 [bumpversion]
-current_version = 2.0.4.dev0
+current_version = 2.0.4
 commit = True
 tag = False
 tag_name = v{new_version}

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -2,6 +2,6 @@
 
 Contributions are absolutely encouraged, for bug fixes, new features, etc.
 
-If you are not sure where to start, check out the [issues](https://github.com/larsrollik/serial_weighing_scale/issues).
+If you are not sure where to start, check out the [issues](https://github.com/larsrollik/serial-weighing-scale/issues).
 
 Please get in touch via [email](mailto:L.B.Rollik@protonmail.com) for other queries.

--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@
 Arduino-based cheap precision weighing scale for readout via serial communication.
 
 ***
-Version: "2.0.4.dev0"
+Version: "2.0.4"
 
 Precision weighing scales that include serial port communication usually come at considerable cost. This project showcases an affordable alternative.
 Using readily available electronics parts, the scale's measurements can be read via serial communication by a simple Python class.

--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@
 Arduino-based cheap precision weighing scale for readout via serial communication.
 
 ***
-Version: "2.0.3"
+Version: "2.0.4.dev0"
 
 Precision weighing scales that include serial port communication usually come at considerable cost. This project showcases an affordable alternative.
 Using readily available electronics parts, the scale's measurements can be read via serial communication by a simple Python class.

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "serial_weighing_scale"
-version = "2.0.4.dev0"
+version = "2.0.4"
 authors = [
     { name = "Lars B. Rollik", email = "L.B.Rollik@protonmail.com" }
 ]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "serial_weighing_scale"
-version = "2.0.3"
+version = "2.0.4.dev0"
 authors = [
     { name = "Lars B. Rollik", email = "L.B.Rollik@protonmail.com" }
 ]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -33,8 +33,8 @@ dependencies = [
 ]
 
 [project.urls]
-Repository = "https://github.com/larsrollik/serial_weighing_scale"
-"Issue Tracker" = "https://github.com/larsrollik/serial_weighing_scale/issues"
+Repository = "https://github.com/larsrollik/serial-weighing-scale"
+"Issue Tracker" = "https://github.com/larsrollik/serial-weighing-scale/issues"
 
 
 [project.optional-dependencies]
@@ -48,7 +48,7 @@ dev = [
 ]
 
 [project.entry-points.console_scripts]
-#serial_weighing_scale-entrypoint = "serial_weighing_scale.__init__:run"
+#serial-weighing-scale-entrypoint = "serial-weighing-scale.__init__:run"
 
 [tool.setuptools]
 zip-safe = false

--- a/scale_firmware/scale_firmware.ino
+++ b/scale_firmware/scale_firmware.ino
@@ -1,8 +1,8 @@
 /*
   Firmware version: "2.0.3"
   -------------------------------------------------------------------------------------
-  Adapted example from HX711 library for `serial_weighing_scale`. Lars Rollik, nov2021.
-  github.com/larsrollik/serial_weighing_scale
+  Adapted example from HX711 library for `serial-weighing-scale`. Lars Rollik, nov2021.
+  github.com/larsrollik/serial-weighing-scale
   -------------------------------------------------------------------------------------
   HX711_ADC
   Arduino library for HX711 24-Bit Analog-to-Digital Converter for Weight Scales

--- a/scale_firmware/scale_firmware.ino
+++ b/scale_firmware/scale_firmware.ino
@@ -1,5 +1,5 @@
 /*
-  Firmware version: "2.0.4.dev0"
+  Firmware version: "2.0.4"
   -------------------------------------------------------------------------------------
   Adapted example from HX711 library for `serial-weighing-scale`. Lars Rollik, nov2021.
   github.com/larsrollik/serial-weighing-scale

--- a/scale_firmware/scale_firmware.ino
+++ b/scale_firmware/scale_firmware.ino
@@ -1,5 +1,5 @@
 /*
-  Firmware version: "2.0.3"
+  Firmware version: "2.0.4.dev0"
   -------------------------------------------------------------------------------------
   Adapted example from HX711 library for `serial-weighing-scale`. Lars Rollik, nov2021.
   github.com/larsrollik/serial-weighing-scale

--- a/serial_weighing_scale/__init__.py
+++ b/serial_weighing_scale/__init__.py
@@ -7,7 +7,7 @@ from serial_weighing_scale.scale import Scale
 try:
     __version__ = version("subject_weight_db")
 except PackageNotFoundError:
-    __version__ = "2.0.4.dev0"
+    __version__ = "2.0.4"
 
 DEFAULT_TEST_PORTS = [f"/dev/ttyACM{x}" for x in range(5)]
 

--- a/serial_weighing_scale/__init__.py
+++ b/serial_weighing_scale/__init__.py
@@ -7,7 +7,7 @@ from serial_weighing_scale.scale import Scale
 try:
     __version__ = version("subject_weight_db")
 except PackageNotFoundError:
-    __version__ = "2.0.3"
+    __version__ = "2.0.4.dev0"
 
 DEFAULT_TEST_PORTS = [f"/dev/ttyACM{x}" for x in range(5)]
 

--- a/tests/minimal_usage.py
+++ b/tests/minimal_usage.py
@@ -1,12 +1,20 @@
 import logging
+from typing import TypedDict
 
 from serial_weighing_scale import SerialWeighingScale
+
+
+class ScaleConfig(TypedDict):
+    serial_port: str
+    baudrate: int
+    timeout: float
+
 
 if __name__ == "__main__":
     logger = logging.getLogger()
     logger.setLevel(logging.DEBUG)
 
-    serial_param = {
+    serial_param: ScaleConfig = {
         "serial_port": "/dev/ttyACM1",
         "baudrate": 115200,
         "timeout": 1,


### PR DESCRIPTION
- **repo moved to dash naming. fixes for mypy typing.**
- **fix**
- **typo**
- **"Upgrade: 2.0.3 → 2.0.4.dev0"**
- **"Upgrade: 2.0.4.dev0 → 2.0.4"**
